### PR TITLE
Updated to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
-php: 
-  - 5.3
-  - 5.4
-  - 5.5
+php:
+  - 7.1
+  - 7.2
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
 
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "laravel/framework": ">=5.5",
         "pragmarx/support": "~0.8",
         "sensiolabs/ansi-to-html": "~1",
@@ -30,7 +30,7 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": ">=5.7",
+        "phpunit/phpunit": "~6.4",
         "orchestra/testbench": "~3.5"
     },
 


### PR DESCRIPTION
Updated to [PHPUnit 6](https://github.com/sebastianbergmann/phpunit), bumped PHP minor version to `7.1`, added PHP versions `7.1` and `7.2` to Travis CI.